### PR TITLE
Fix duplicate middleware in settings

### DIFF
--- a/teacher_dashboard/settings.py
+++ b/teacher_dashboard/settings.py
@@ -43,14 +43,12 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "django.middleware.locale.LocaleMiddleware", 
-    "django.middleware.common.CommonMiddleware",
-    "django.middleware.csrf.CsrfViewMiddleware",
 ]
 
 ROOT_URLCONF = "teacher_dashboard.urls"


### PR DESCRIPTION
## Summary
- deduplicate middleware entries
- use recommended order of session, locale, common, csrf

## Testing
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_68779586cadc83239dfb08ee59628c12