### PR TITLE
Fix duplicate i18n settings

### DIFF
--- a/teacher_dashboard/settings.py
+++ b/teacher_dashboard/settings.py
@@ -105,18 +105,6 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 
-# Internationalization
-# https://docs.djangoproject.com/en/5.2/topics/i18n/
-
-LANGUAGE_CODE = "en-us"
-
-TIME_ZONE = "UTC"
-
-USE_I18N = True
-
-USE_TZ = True
-
-
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 


### PR DESCRIPTION
## Summary
- remove duplicate `LANGUAGE_CODE`, `USE_I18N`, and `USE_TZ` entries from `settings.py`

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6877958837d48323b096e92d1279fc73